### PR TITLE
ブログデザイン・Markdown機能の改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ pnpm-debug.log*
 
 # typescript
 *.tsbuildinfo
+
+# build-time fetch cache
+/.cache/

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -6,6 +6,7 @@ import remarkDirective from 'remark-directive';
 import { remarkImageSize } from './src/lib/remark-image-size';
 import { remarkZennMessage } from './src/lib/remark-zenn-message';
 import { rehypeTwitterEmbed } from './src/lib/rehype-twitter-embed';
+import { rehypeLinkCard } from './src/lib/rehype-link-card';
 
 function rehypeHeadingIds() {
   return (tree: any) => {
@@ -58,6 +59,6 @@ export default defineConfig({
       wrap: true,
     },
     remarkPlugins: [remarkImageSize, remarkDirective, remarkZennMessage],
-    rehypePlugins: [rehypeHeadingIds, rehypeTwitterEmbed],
+    rehypePlugins: [rehypeHeadingIds, rehypeTwitterEmbed, rehypeLinkCard],
   },
 });

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
+import remarkDirective from 'remark-directive';
 import { remarkImageSize } from './src/lib/remark-image-size';
+import { remarkZennMessage } from './src/lib/remark-zenn-message';
 import { rehypeTwitterEmbed } from './src/lib/rehype-twitter-embed';
 
 function rehypeHeadingIds() {
@@ -55,7 +57,7 @@ export default defineConfig({
       theme: 'dark-plus',
       wrap: true,
     },
-    remarkPlugins: [remarkImageSize],
+    remarkPlugins: [remarkImageSize, remarkDirective, remarkZennMessage],
     rehypePlugins: [rehypeHeadingIds, rehypeTwitterEmbed],
   },
 });

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -3,6 +3,7 @@ import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 import { remarkImageSize } from './src/lib/remark-image-size';
+import { rehypeTwitterEmbed } from './src/lib/rehype-twitter-embed';
 
 function rehypeHeadingIds() {
   return (tree: any) => {
@@ -55,6 +56,6 @@ export default defineConfig({
       wrap: true,
     },
     remarkPlugins: [remarkImageSize],
-    rehypePlugins: [rehypeHeadingIds],
+    rehypePlugins: [rehypeHeadingIds, rehypeTwitterEmbed],
   },
 });

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
+import { remarkImageSize } from './src/lib/remark-image-size';
 
 function rehypeHeadingIds() {
   return (tree: any) => {
@@ -53,6 +54,7 @@ export default defineConfig({
       theme: 'dark-plus',
       wrap: true,
     },
+    remarkPlugins: [remarkImageSize],
     rehypePlugins: [rehypeHeadingIds],
   },
 });

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "astro": "^6.1.2",
     "cloudinary": "^2.7.0",
     "gray-matter": "^4.0.3",
+    "open-graph-scraper": "^6.12.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-share": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-share": "^5.3.0",
     "satori": "^0.26.0",
     "shiki": "^3.6.0",
-    "tailwindcss": "^4.1.10"
+    "tailwindcss": "^4.1.10",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gray-matter": "^4.0.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-share": "^5.3.0",
     "satori": "^0.26.0",
     "shiki": "^3.6.0",
     "tailwindcss": "^4.1.10"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-share": "^5.3.0",
+    "remark-directive": "^4.0.0",
     "satori": "^0.26.0",
     "shiki": "^3.6.0",
     "tailwindcss": "^4.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      react-share:
+        specifier: ^5.3.0
+        version: 5.3.0(react@19.2.4)
       satori:
         specifier: ^0.26.0
         version: 0.26.0
@@ -1493,6 +1496,9 @@ packages:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
+
   cloudinary@2.9.0:
     resolution: {integrity: sha512-F3iKMOy4y0zy0bi5JBp94SC7HY7i/ImfTPSUV07iJmRzH1Iz8WavFfOlJTR1zvYM/xKGoiGZ3my/zy64In0IQQ==}
     engines: {node: '>=9'}
@@ -1571,6 +1577,14 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1840,6 +1854,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonp@0.2.1:
+    resolution: {integrity: sha512-pfog5gdDxPdV4eP7Kg87M8/bHgshlZ5pybl+yKxAnCZ5O7lCIn7Ixydj03wOlnDQesky2BPyA91SQ+5Y/mNwzw==}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -2166,6 +2183,9 @@ packages:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
 
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2307,6 +2327,11 @@ packages:
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
+
+  react-share@5.3.0:
+    resolution: {integrity: sha512-NU4TqizVi2TuyLpN93/ng2ux+uIGHK5b2dT15cHvZDwfi5b5NuzGych4htCGObN8lubygeamhRxUot4lZ0Pv6Q==}
+    peerDependencies:
+      react: ^17 || ^18 || ^19
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -3966,6 +3991,8 @@ snapshots:
 
   ci-info@4.4.0: {}
 
+  classnames@2.5.1: {}
+
   cloudinary@2.9.0:
     dependencies:
       lodash: 4.17.23
@@ -4031,6 +4058,10 @@ snapshots:
       css-tree: 2.2.1
 
   csstype@3.2.3: {}
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
 
   debug@4.4.3:
     dependencies:
@@ -4357,6 +4388,12 @@ snapshots:
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
+
+  jsonp@0.2.1:
+    dependencies:
+      debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
 
   kind-of@6.0.3: {}
 
@@ -4820,6 +4857,8 @@ snapshots:
 
   mrmime@2.0.1: {}
 
+  ms@2.0.0: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -4956,6 +4995,14 @@ snapshots:
       scheduler: 0.27.0
 
   react-refresh@0.18.0: {}
+
+  react-share@5.3.0(react@19.2.4):
+    dependencies:
+      classnames: 2.5.1
+      jsonp: 0.2.1
+      react: 19.2.4
+    transitivePeerDependencies:
+      - supports-color
 
   react@19.2.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      open-graph-scraper:
+        specifier: ^6.12.0
+        version: 6.12.0
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -1500,6 +1503,16 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  chardet@2.2.0:
+    resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
+
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
@@ -1661,6 +1674,9 @@ packages:
     resolution: {integrity: sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==}
     engines: {node: '>=10.0.0'}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
     engines: {node: '>=10.13.0'}
@@ -1675,6 +1691,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   error-stack-parser-es@1.0.5:
@@ -1814,8 +1834,19 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -2262,6 +2293,10 @@ packages:
   oniguruma-to-es@4.3.4:
     resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
 
+  open-graph-scraper@6.12.0:
+    resolution: {integrity: sha512-x0fS3eHxdCox+rFBhQSVe+qBznSPn1pspp8A4BoaVEkiECZEwagEb8z06swLfaFFE2gefj1BvEBeJmdeGTDnYw==}
+    engines: {node: '>=20.0.0'}
+
   oxfmt@0.27.0:
     resolution: {integrity: sha512-FHR0HR3WeMKBuVEQvW3EeiRZXs/cQzNHxGbhCoAIEPr1FVcOa9GCqrKJXPqv2jkzmCg6Wqot+DvN9RzemyFJhw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2303,6 +2338,12 @@ packages:
 
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -2430,6 +2471,9 @@ packages:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   satori@0.26.0:
     resolution: {integrity: sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==}
@@ -2588,6 +2632,10 @@ packages:
 
   undici@7.18.2:
     resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -2759,6 +2807,15 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
@@ -4025,6 +4082,31 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  chardet@2.2.0: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.28.0
+      whatwg-mimetype: 4.0.0
+
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
@@ -4153,6 +4235,11 @@ snapshots:
 
   emoji-regex-xs@2.0.1: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
   enhanced-resolve@5.18.4:
     dependencies:
       graceful-fs: 4.2.11
@@ -4166,6 +4253,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   error-stack-parser-es@1.0.5: {}
 
@@ -4394,7 +4483,22 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-cache-semantics@4.2.0: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iron-webcrypto@1.2.1: {}
 
@@ -4974,6 +5078,13 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  open-graph-scraper@6.12.0:
+    dependencies:
+      chardet: 2.2.0
+      cheerio: 1.2.0
+      iconv-lite: 0.7.3
+      undici: 7.28.0
+
   oxfmt@0.27.0:
     dependencies:
       tinypool: 2.0.0
@@ -5036,6 +5147,15 @@ snapshots:
       unist-util-modify-children: 4.0.0
       unist-util-visit-children: 3.0.0
       vfile: 6.0.3
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
 
   parse5@7.3.0:
     dependencies:
@@ -5234,6 +5354,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  safer-buffer@2.1.2: {}
+
   satori@0.26.0:
     dependencies:
       '@shuding/opentype.js': 1.4.0-beta.0
@@ -5402,6 +5524,8 @@ snapshots:
 
   undici@7.18.2: {}
 
+  undici@7.28.0: {}
+
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
@@ -5523,6 +5647,12 @@ snapshots:
       vite: 7.3.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
   web-namespaces@2.0.1: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   which-pm-runs@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       react-share:
         specifier: ^5.3.0
         version: 5.3.0(react@19.2.4)
+      remark-directive:
+        specifier: ^4.0.0
+        version: 4.0.0
       satori:
         specifier: ^0.26.0
         version: 0.26.0
@@ -1409,6 +1412,9 @@ packages:
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -1490,6 +1496,9 @@ packages:
 
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -1811,6 +1820,15 @@ packages:
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1819,6 +1837,9 @@ packages:
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
@@ -2051,6 +2072,9 @@ packages:
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
 
+  mdast-util-directive@3.1.0:
+    resolution: {integrity: sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==}
+
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
@@ -2095,6 +2119,9 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-directive@4.0.0:
+    resolution: {integrity: sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==}
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
@@ -2271,6 +2298,9 @@ packages:
   parse-css-color@0.2.1:
     resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
 
@@ -2364,6 +2394,9 @@ packages:
 
   rehype@13.0.2:
     resolution: {integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==}
+
+  remark-directive@4.0.0:
+    resolution: {integrity: sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -3829,6 +3862,8 @@ snapshots:
     dependencies:
       '@types/node': 20.19.30
 
+  '@types/unist@2.0.11': {}
+
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.0': {}
@@ -3987,6 +4022,8 @@ snapshots:
   character-entities-legacy@3.0.0: {}
 
   character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chokidar@5.0.0:
     dependencies:
@@ -4361,9 +4398,20 @@ snapshots:
 
   iron-webcrypto@1.2.1: {}
 
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
+
   is-docker@3.0.0: {}
 
   is-extendable@0.1.1: {}
+
+  is-hexadecimal@2.0.1: {}
 
   is-inside-container@1.0.0:
     dependencies:
@@ -4537,6 +4585,20 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-visit: 5.1.0
 
+  mdast-util-directive@3.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-visit-parents: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-find-and-replace@3.0.2:
     dependencies:
       '@types/mdast': 4.0.4
@@ -4673,6 +4735,16 @@ snapshots:
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
+
+  micromark-extension-directive@4.0.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      parse-entities: 4.0.2
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     dependencies:
@@ -4946,6 +5018,16 @@ snapshots:
       color-name: 1.1.4
       hex-rgb: 4.3.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-latin@7.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -5045,6 +5127,15 @@ snapshots:
       rehype-parse: 9.0.1
       rehype-stringify: 10.0.1
       unified: 11.0.5
+
+  remark-directive@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-directive: 3.1.0
+      micromark-extension-directive: 4.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   remark-gfm@4.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.10
         version: 4.1.18
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
     devDependencies:
       '@types/node':
         specifier: ^20

--- a/src/components/SocialShareButtons.tsx
+++ b/src/components/SocialShareButtons.tsx
@@ -1,3 +1,5 @@
+import { HatenaIcon, HatenaShareButton, LinkedinIcon, LinkedinShareButton, TwitterIcon, TwitterShareButton } from 'react-share';
+
 interface SocialShareButtonsProps {
   title: string;
   url: string;
@@ -5,52 +7,21 @@ interface SocialShareButtonsProps {
 }
 
 export default function SocialShareButtons({ title, url }: SocialShareButtonsProps) {
-  const encodedTitle = encodeURIComponent(title);
-  const encodedUrl = encodeURIComponent(url);
-
-  const shareUrls = {
-    twitter: `https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedUrl}`,
-    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
-    hatena: `https://b.hatena.ne.jp/entry/panel/?url=${encodedUrl}&title=${encodedTitle}`,
-  };
-
-  const handleShare = (platform: keyof typeof shareUrls) => {
-    window.open(shareUrls[platform], '_blank', 'width=600,height=400');
-  };
-
   return (
     <div className="flex items-center gap-4">
       <span className="text-sm text-gray-400 dark:text-gray-500">Share:</span>
 
-      <button
-        onClick={() => handleShare('twitter')}
-        className="text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
-        aria-label="Share on Twitter"
-      >
-        <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-        </svg>
-      </button>
+      <TwitterShareButton url={url} title={title}>
+        <TwitterIcon size={32} round />
+      </TwitterShareButton>
 
-      <button
-        onClick={() => handleShare('linkedin')}
-        className="text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
-        aria-label="Share on LinkedIn"
-      >
-        <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-        </svg>
-      </button>
+      <LinkedinShareButton url={url} title={title}>
+        <LinkedinIcon size={32} round />
+      </LinkedinShareButton>
 
-      <button
-        onClick={() => handleShare('hatena')}
-        className="text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
-        aria-label="Share on Hatena Bookmark"
-      >
-        <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm-2.5 8.5h2v7h-2v-7zm1 8.5c-.828 0-1.5-.672-1.5-1.5S9.672 15 10.5 15s1.5.672 1.5 1.5-.672 1.5-1.5 1.5zm4.5-8.5c-1.657 0-3-1.343-3-3s1.343-3 3-3 3 1.343 3 3-1.343 3-3 3z" />
-        </svg>
-      </button>
+      <HatenaShareButton url={url} title={title}>
+        <HatenaIcon size={32} round />
+      </HatenaShareButton>
     </div>
   );
 }

--- a/src/components/SocialShareButtons.tsx
+++ b/src/components/SocialShareButtons.tsx
@@ -1,4 +1,11 @@
-import { HatenaIcon, HatenaShareButton, LinkedinIcon, LinkedinShareButton, TwitterIcon, TwitterShareButton } from 'react-share';
+import {
+  HatenaIcon,
+  HatenaShareButton,
+  LinkedinIcon,
+  LinkedinShareButton,
+  TwitterIcon,
+  TwitterShareButton,
+} from 'react-share';
 
 interface SocialShareButtonsProps {
   title: string;

--- a/src/components/SocialShareButtons.tsx
+++ b/src/components/SocialShareButtons.tsx
@@ -1,10 +1,10 @@
 import {
+  BlueskyIcon,
+  BlueskyShareButton,
   HatenaIcon,
   HatenaShareButton,
-  LinkedinIcon,
-  LinkedinShareButton,
-  TwitterIcon,
-  TwitterShareButton,
+  XIcon,
+  XShareButton,
 } from 'react-share';
 
 interface SocialShareButtonsProps {
@@ -18,13 +18,13 @@ export default function SocialShareButtons({ title, url }: SocialShareButtonsPro
     <div className="flex items-center gap-4">
       <span className="text-sm text-gray-400 dark:text-gray-500">Share:</span>
 
-      <TwitterShareButton url={url} title={title}>
-        <TwitterIcon size={32} round />
-      </TwitterShareButton>
+      <XShareButton url={url} title={title}>
+        <XIcon size={32} round />
+      </XShareButton>
 
-      <LinkedinShareButton url={url} title={title}>
-        <LinkedinIcon size={32} round />
-      </LinkedinShareButton>
+      <BlueskyShareButton url={url} title={title}>
+        <BlueskyIcon size={32} round />
+      </BlueskyShareButton>
 
       <HatenaShareButton url={url} title={title}>
         <HatenaIcon size={32} round />

--- a/src/lib/hast-utils.ts
+++ b/src/lib/hast-utils.ts
@@ -1,0 +1,20 @@
+function getSoleTextValue(node: any): string | null {
+  if (node.children?.length !== 1) return null;
+  const child = node.children[0];
+  return child.type === 'text' ? child.value : null;
+}
+
+// A <p> containing nothing but a link whose text is the link's own URL,
+// e.g. a URL pasted on its own line in Markdown.
+export function getBareLinkHref(node: any): string | null {
+  if (node.tagName !== 'p' || node.children.length !== 1) return null;
+
+  const link = node.children[0];
+  if (link.type !== 'element' || link.tagName !== 'a') return null;
+
+  const href = link.properties?.href;
+  if (typeof href !== 'string') return null;
+  if (getSoleTextValue(link) !== href) return null;
+
+  return href;
+}

--- a/src/lib/link-card-data.ts
+++ b/src/lib/link-card-data.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import ogs from 'open-graph-scraper';
+
+export interface LinkCardData {
+  url: string;
+  title: string;
+  description?: string;
+  image?: string;
+  favicon?: string;
+  siteName?: string;
+}
+
+const FETCH_TIMEOUT_MS = 8000;
+const CACHE_FILE = path.resolve('.cache/link-cards.json');
+
+const cache = loadDiskCache();
+
+function loadDiskCache(): Record<string, LinkCardData | null> {
+  try {
+    return JSON.parse(readFileSync(CACHE_FILE, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+function saveDiskCache() {
+  try {
+    mkdirSync(path.dirname(CACHE_FILE), { recursive: true });
+    writeFileSync(CACHE_FILE, JSON.stringify(cache, null, 2));
+  } catch {
+    // Best-effort cache; a write failure shouldn't break the build.
+  }
+}
+
+function resolveUrl(maybeUrl: string | undefined, base: string): string | undefined {
+  if (!maybeUrl) return undefined;
+  try {
+    return new URL(maybeUrl, base).href;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function fetchLinkCardData(url: string): Promise<LinkCardData | null> {
+  if (url in cache) return cache[url];
+
+  let data: LinkCardData | null = null;
+  try {
+    const { error, result } = await ogs({ url, timeout: FETCH_TIMEOUT_MS });
+    if (!error && result.success) {
+      const title = result.ogTitle || result.twitterTitle || result.dcTitle;
+      if (title) {
+        data = {
+          url,
+          title,
+          description: result.ogDescription || result.twitterDescription,
+          image: resolveUrl(result.ogImage?.[0]?.url, url),
+          favicon: resolveUrl(result.favicon, url),
+          siteName: result.ogSiteName,
+        };
+      }
+    }
+  } catch {
+    data = null;
+  }
+
+  cache[url] = data;
+  saveDiskCache();
+  return data;
+}

--- a/src/lib/rehype-link-card.ts
+++ b/src/lib/rehype-link-card.ts
@@ -1,0 +1,99 @@
+import { visit } from 'unist-util-visit';
+import { getBareLinkHref } from './hast-utils';
+import { isTweetUrl } from './rehype-twitter-embed';
+import { fetchLinkCardData, type LinkCardData } from './link-card-data';
+
+function buildCardChildren(data: LinkCardData): any[] {
+  const textChildren: any[] = [
+    {
+      type: 'element',
+      tagName: 'p',
+      properties: { className: ['link-card-title'] },
+      children: [{ type: 'text', value: data.title }],
+    },
+  ];
+
+  if (data.description) {
+    textChildren.push({
+      type: 'element',
+      tagName: 'p',
+      properties: { className: ['link-card-description'] },
+      children: [{ type: 'text', value: data.description }],
+    });
+  }
+
+  const metaChildren: any[] = [];
+  if (data.favicon) {
+    metaChildren.push({
+      type: 'element',
+      tagName: 'img',
+      properties: { className: ['link-card-favicon'], src: data.favicon, alt: '' },
+      children: [],
+    });
+  }
+  metaChildren.push({
+    type: 'element',
+    tagName: 'span',
+    properties: { className: ['link-card-domain'] },
+    children: [{ type: 'text', value: data.siteName || new URL(data.url).hostname }],
+  });
+
+  textChildren.push({
+    type: 'element',
+    tagName: 'div',
+    properties: { className: ['link-card-meta'] },
+    children: metaChildren,
+  });
+
+  const children: any[] = [
+    {
+      type: 'element',
+      tagName: 'div',
+      properties: { className: ['link-card-body'] },
+      children: textChildren,
+    },
+  ];
+
+  if (data.image) {
+    children.push({
+      type: 'element',
+      tagName: 'div',
+      properties: { className: ['link-card-thumbnail'] },
+      children: [
+        { type: 'element', tagName: 'img', properties: { src: data.image, alt: '' }, children: [] },
+      ],
+    });
+  }
+
+  return children;
+}
+
+// Turns a paragraph containing only a bare URL into a card-style preview
+// linking out to the page, using its OGP metadata (fetched at build time).
+export function rehypeLinkCard() {
+  return async (tree: any) => {
+    const targets: { node: any; href: string }[] = [];
+
+    visit(tree, 'element', (node: any) => {
+      const href = getBareLinkHref(node);
+      if (!href || !/^https?:\/\//.test(href) || isTweetUrl(href)) return;
+      targets.push({ node, href });
+    });
+
+    await Promise.all(
+      targets.map(async ({ node, href }) => {
+        const data = await fetchLinkCardData(href);
+        if (!data) return;
+
+        node.tagName = 'a';
+        node.properties = {
+          className: ['link-card'],
+          href: data.url,
+          target: '_blank',
+          rel: ['noopener', 'noreferrer'],
+        };
+        node.children = buildCardChildren(data);
+      }),
+    );
+  };
+}

--- a/src/lib/rehype-twitter-embed.ts
+++ b/src/lib/rehype-twitter-embed.ts
@@ -1,4 +1,5 @@
 import { visit } from 'unist-util-visit';
+import { getBareLinkHref } from './hast-utils';
 
 // Matches a bare link to a single tweet, e.g. https://x.com/user/status/123
 const TWEET_URL_SOURCE = 'https?://(?:twitter\\.com|x\\.com)/[^/\\s]+/status/\\d+(?:\\?\\S*)?';
@@ -8,10 +9,8 @@ export function containsTweetUrl(text: string): boolean {
   return new RegExp(TWEET_URL_SOURCE).test(text);
 }
 
-function getSoleTextValue(node: any): string | null {
-  if (node.children?.length !== 1) return null;
-  const child = node.children[0];
-  return child.type === 'text' ? child.value : null;
+export function isTweetUrl(url: string): boolean {
+  return TWEET_URL_PATTERN.test(url);
 }
 
 // Turns a paragraph containing only a bare tweet URL into a twitter-tweet
@@ -19,14 +18,8 @@ function getSoleTextValue(node: any): string | null {
 export function rehypeTwitterEmbed() {
   return (tree: any) => {
     visit(tree, 'element', (node: any) => {
-      if (node.tagName !== 'p' || node.children.length !== 1) return;
-
-      const link = node.children[0];
-      if (link.type !== 'element' || link.tagName !== 'a') return;
-
-      const href = link.properties?.href;
-      if (typeof href !== 'string' || !TWEET_URL_PATTERN.test(href)) return;
-      if (getSoleTextValue(link) !== href) return;
+      const href = getBareLinkHref(node);
+      if (!href || !TWEET_URL_PATTERN.test(href)) return;
 
       node.tagName = 'blockquote';
       node.properties = { className: ['twitter-tweet'] };

--- a/src/lib/rehype-twitter-embed.ts
+++ b/src/lib/rehype-twitter-embed.ts
@@ -1,0 +1,36 @@
+import { visit } from 'unist-util-visit';
+
+// Matches a bare link to a single tweet, e.g. https://x.com/user/status/123
+const TWEET_URL_SOURCE = 'https?://(?:twitter\\.com|x\\.com)/[^/\\s]+/status/\\d+(?:\\?\\S*)?';
+const TWEET_URL_PATTERN = new RegExp(`^${TWEET_URL_SOURCE}$`);
+
+export function containsTweetUrl(text: string): boolean {
+  return new RegExp(TWEET_URL_SOURCE).test(text);
+}
+
+function getSoleTextValue(node: any): string | null {
+  if (node.children?.length !== 1) return null;
+  const child = node.children[0];
+  return child.type === 'text' ? child.value : null;
+}
+
+// Turns a paragraph containing only a bare tweet URL into a twitter-tweet
+// blockquote, which Twitter's widgets.js hydrates into a full embed on the client.
+export function rehypeTwitterEmbed() {
+  return (tree: any) => {
+    visit(tree, 'element', (node: any) => {
+      if (node.tagName !== 'p' || node.children.length !== 1) return;
+
+      const link = node.children[0];
+      if (link.type !== 'element' || link.tagName !== 'a') return;
+
+      const href = link.properties?.href;
+      if (typeof href !== 'string' || !TWEET_URL_PATTERN.test(href)) return;
+      if (getSoleTextValue(link) !== href) return;
+
+      node.tagName = 'blockquote';
+      node.properties = { className: ['twitter-tweet'] };
+      node.children = [{ type: 'element', tagName: 'a', properties: { href }, children: [] }];
+    });
+  };
+}

--- a/src/lib/remark-image-size.ts
+++ b/src/lib/remark-image-size.ts
@@ -1,0 +1,28 @@
+import { visit } from 'unist-util-visit';
+
+// Zenn-style image size syntax: ![alt](image.jpg =250x) / (=x250) / (=250x250)
+// CommonMark doesn't allow an unquoted space inside a link destination, so this
+// pattern is rewritten into a valid `title` attribute before parsing, then read
+// back out and converted into width/height attributes on the image element.
+const RAW_SYNTAX_PATTERN = /!\[([^\]]*)\]\(([^()\s]+)\s+=(\d+x\d*|\d*x\d+)\)/g;
+const SIZE_TITLE_PATTERN = /^size=(\d*)x(\d*)$/;
+
+export function remarkImageSize(this: any) {
+  const previousParser = this.parser;
+  this.parser = (doc: string, file: any) =>
+    previousParser(doc.replace(RAW_SYNTAX_PATTERN, '![$1]($2 "size=$3")'), file);
+
+  return (tree: any) => {
+    visit(tree, 'image', (node: any) => {
+      const match = node.title?.match(SIZE_TITLE_PATTERN);
+      if (!match) return;
+
+      const [, width, height] = match;
+      node.title = null;
+      node.data ??= {};
+      node.data.hProperties ??= {};
+      if (width) node.data.hProperties.width = width;
+      if (height) node.data.hProperties.height = height;
+    });
+  };
+}

--- a/src/lib/remark-zenn-message.ts
+++ b/src/lib/remark-zenn-message.ts
@@ -1,0 +1,31 @@
+import { visit } from 'unist-util-visit';
+
+// Zenn-style message syntax:
+// :::message
+// ...
+// :::
+// :::message alert
+// ...
+// :::
+// The "alert" variant isn't valid remark-directive attribute syntax, so it's
+// rewritten into `:::message{.alert}` before parsing.
+const ALERT_FENCE_PATTERN = /^:::message[ \t]+alert[ \t]*$/gm;
+
+export function remarkZennMessage(this: any) {
+  const previousParser = this.parser;
+  this.parser = (doc: string, file: any) =>
+    previousParser(doc.replace(ALERT_FENCE_PATTERN, ':::message{.alert}'), file);
+
+  return (tree: any) => {
+    visit(tree, 'containerDirective', (node: any) => {
+      if (node.name !== 'message') return;
+
+      const isAlert = node.attributes?.class === 'alert';
+      node.data ??= {};
+      node.data.hName = 'div';
+      node.data.hProperties = {
+        className: ['msg-block', isAlert ? 'msg-block-alert' : 'msg-block-info'],
+      };
+    });
+  };
+}

--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -5,6 +5,7 @@ import SocialShareButtons from '../../components/SocialShareButtons';
 import TableOfContents from '../../components/TableOfContents';
 import { SITE_CONFIG, getBaseUrl } from '../../lib/site-config';
 import { generateArticleJsonLd, generateBreadcrumbJsonLd } from '../../lib/structured-data';
+import { containsTweetUrl } from '../../lib/rehype-twitter-embed';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
@@ -39,6 +40,7 @@ const breadcrumbJsonLd = generateBreadcrumbJsonLd([
 ]);
 
 const ogImageUrl = `${baseUrl}/og/${post.id}.png`;
+const hasTwitterEmbed = containsTweetUrl(post.body ?? '');
 ---
 
 <BaseLayout
@@ -82,6 +84,7 @@ const ogImageUrl = `${baseUrl}/og/${post.id}.png`;
         <div class="prose prose-lg max-w-none">
           <Content />
         </div>
+        {hasTwitterEmbed && <script async src="https://platform.twitter.com/widgets.js" charset="utf-8" />}
 
         <footer class="mt-12 pt-6 border-t border-gray-100 dark:border-gray-800">
           <SocialShareButtons client:load title={post.data.title} url={currentUrl} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -201,6 +201,110 @@ body {
   font-style: normal;
 }
 
+/* Link cards: build-time OGP preview for bare URLs */
+.prose a.link-card {
+  display: flex;
+  align-items: stretch;
+  gap: 1rem;
+  margin: 1.5rem 0;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.2s;
+}
+
+.prose a.link-card:hover {
+  border-color: #9ca3af;
+}
+
+.dark .prose a.link-card {
+  border-color: #374151;
+}
+
+.dark .prose a.link-card:hover {
+  border-color: #6b7280;
+}
+
+.prose .link-card-body {
+  flex: 1;
+  min-width: 0;
+  padding: 0.875rem 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.375rem;
+}
+
+.prose .link-card-title {
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: #111827;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.dark .prose .link-card-title {
+  color: #f9fafb;
+}
+
+.prose .link-card-description {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: #6b7280;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.dark .prose .link-card-description {
+  color: #9ca3af;
+}
+
+.prose .link-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.prose .link-card-favicon {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  border-radius: 2px;
+}
+
+.prose .link-card-domain {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.prose .link-card-thumbnail {
+  flex-shrink: 0;
+  width: 120px;
+}
+
+.prose .link-card-thumbnail img {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  object-fit: cover;
+}
+
+@media (max-width: 480px) {
+  .prose .link-card-thumbnail {
+    width: 88px;
+  }
+}
+
 .prose ul,
 .prose ol {
   margin: 1.25rem 0;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -135,6 +135,15 @@ body {
   color: #9ca3af;
 }
 
+/* Reset blockquote styling for Twitter/X embeds; widgets.js replaces the
+   element client-side, so this only affects the brief pre-hydration state. */
+.prose blockquote.twitter-tweet {
+  border-left: none;
+  padding-left: 0;
+  margin: 1.5rem 0;
+  font-style: normal;
+}
+
 .prose ul,
 .prose ol {
   margin: 1.25rem 0;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -137,10 +137,19 @@ body {
 
 /* Zenn-style :::message blocks */
 .prose .msg-block {
+  position: relative;
   margin: 1.5rem 0;
-  padding: 1rem 1.25rem;
+  padding: 1rem 1.25rem 1rem 3rem;
   border-radius: 0.5rem;
   border: 1px solid;
+}
+
+.prose .msg-block::before {
+  position: absolute;
+  left: 1rem;
+  top: 1rem;
+  font-size: 1.125rem;
+  line-height: 1.5rem;
 }
 
 .prose .msg-block > :first-child {
@@ -157,6 +166,10 @@ body {
   color: #0c4a6e;
 }
 
+.prose .msg-block-info::before {
+  content: '💡';
+}
+
 .dark .prose .msg-block-info {
   background-color: rgba(56, 189, 248, 0.1);
   border-color: rgba(56, 189, 248, 0.3);
@@ -167,6 +180,10 @@ body {
   background-color: #fffbeb;
   border-color: #fde68a;
   color: #78350f;
+}
+
+.prose .msg-block-alert::before {
+  content: '⚠️';
 }
 
 .dark .prose .msg-block-alert {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -135,6 +135,46 @@ body {
   color: #9ca3af;
 }
 
+/* Zenn-style :::message blocks */
+.prose .msg-block {
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  border-radius: 0.5rem;
+  border: 1px solid;
+}
+
+.prose .msg-block > :first-child {
+  margin-top: 0;
+}
+
+.prose .msg-block > :last-child {
+  margin-bottom: 0;
+}
+
+.prose .msg-block-info {
+  background-color: #f0f9ff;
+  border-color: #bae6fd;
+  color: #0c4a6e;
+}
+
+.dark .prose .msg-block-info {
+  background-color: rgba(56, 189, 248, 0.1);
+  border-color: rgba(56, 189, 248, 0.3);
+  color: #bae6fd;
+}
+
+.prose .msg-block-alert {
+  background-color: #fffbeb;
+  border-color: #fde68a;
+  color: #78350f;
+}
+
+.dark .prose .msg-block-alert {
+  background-color: rgba(251, 191, 36, 0.1);
+  border-color: rgba(251, 191, 36, 0.3);
+  color: #fde68a;
+}
+
 /* Reset blockquote styling for Twitter/X embeds; widgets.js replaces the
    element client-side, so this only affects the brief pre-hydration state. */
 .prose blockquote.twitter-tweet {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -79,6 +79,11 @@ body {
   margin-bottom: 1.25rem;
 }
 
+.prose img {
+  max-width: 100%;
+  height: auto;
+}
+
 /* Shiki code block styling */
 .prose pre.astro-code {
   border-radius: 0.5rem;


### PR DESCRIPTION
## Summary
- シェアボタンを `react-share` に置き換え、X / Bluesky / はてなブックマークの3種類に統一 (#2)
- Markdownで画像サイズ指定 (`![alt](image.jpg =250x)` 等) をサポート (#4)
- X(Twitter)の単独URLをツイートカードとして自動埋め込み (#6)
- Zenn記法の `:::message` / `:::message alert` ブロックをサポート（左側にアイコン表示） (#28)
- 単独URLをOGPメタデータベースのリンクカードに自動展開（ビルド時取得・キャッシュ付き） (#29)

## Test plan
- [x] `pnpm build` が正常に完了することを確認
- [x] `pnpm lint` / `pnpm format:check` がエラーなしであることを確認
- [x] 各Markdown拡張記法をテスト記事で実際にビルドし、生成HTMLを確認
  - 画像サイズ指定（=250x, =x250, =250x250）
  - Twitter/X埋め込み（プレーンURL / インラインリンクの区別）
  - メッセージブロック（info / alert）
  - リンクカード（正常系・取得失敗時のフォールバック）
- [ ] 本番ビルド環境（Cloudflare）でのデプロイ確認

Closes #2, #4, #6, #28, #29