### PR TITLE
fix: Google Analyticsが本番で計測されない問題を修正

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,3 @@
-# Google Analytics
-NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
-
 # Cloudinary
 NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=your-cloud-name
 CLOUDINARY_API_KEY=your-api-key

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Technical Blog
 
-A modern technical blog built with Next.js 15 and deployed on Cloudflare Workers, designed for sharing programming knowledge and learning experiences.
+A modern technical blog built with Astro and deployed on Cloudflare Workers, designed for sharing programming knowledge and learning experiences.
 
 ## Features
 
@@ -19,15 +19,15 @@ A modern technical blog built with Next.js 15 and deployed on Cloudflare Workers
 1. Clone the repository
 2. Install dependencies:
    ```bash
-   npm install
+   pnpm install
    ```
 
 3. Start the development server:
    ```bash
-   npm run dev
+   pnpm dev
    ```
 
-4. Open [http://localhost:3000](http://localhost:3000) to view the site
+4. Open [http://localhost:4321](http://localhost:4321) to view the site
 
 ### Writing Articles
 
@@ -50,15 +50,11 @@ A modern technical blog built with Next.js 15 and deployed on Cloudflare Workers
 
 ### Google Analytics Setup
 
-1. Create a Google Analytics 4 property
-2. Get your measurement ID (format: `G-XXXXXXXXXX`)
-3. Set the environment variable:
-   ```bash
-   cp .env.local.example .env.local
-   # Edit .env.local and add your GA ID
-   ```
+The GA4 measurement ID is defined as a constant in [`src/lib/site-config.ts`](src/lib/site-config.ts) (`SITE_CONFIG.analytics.gaId`). It is only injected into production builds (`import.meta.env.PROD`) — `pnpm dev` / `astro preview` never load the GA script, so local traffic is never tracked.
 
-For detailed setup instructions, see [docs/google-analytics-setup.md](docs/google-analytics-setup.md).
+To change the measurement ID, edit `SITE_CONFIG.analytics.gaId` directly.
+
+For details on why this is a build-time constant rather than an environment variable, see [docs/google-analytics-setup.md](docs/google-analytics-setup.md).
 
 ### Cloudinary Setup (for Image Upload)
 
@@ -75,11 +71,12 @@ For detailed setup instructions, see [docs/google-analytics-setup.md](docs/googl
 
 ### Environment Variables
 
-- `NEXT_PUBLIC_SITE_URL`: Your site URL (required for SEO)
-- `NEXT_PUBLIC_GA_ID`: Google Analytics measurement ID (optional)
+- `PUBLIC_SITE_URL`: Overrides the site URL used for canonical links (optional; falls back to `SITE_CONFIG.url.base` in `src/lib/site-config.ts`)
 - `NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME`: Cloudinary cloud name (required for image upload)
 - `CLOUDINARY_API_KEY`: Cloudinary API key (required for image upload)
 - `CLOUDINARY_API_SECRET`: Cloudinary API secret (required for image upload)
+
+Note: this project is a fully static Astro site (`output: 'static'`, no adapter). `astro build` runs entirely at build time, so only environment variables present in the shell (or an `.env` file) *at build time* take effect — values set in `wrangler.jsonc`'s `vars` are never read, since there is no server-side Worker script to read them.
 
 ## Deployment
 
@@ -87,25 +84,20 @@ This project is configured for Cloudflare Workers deployment:
 
 ```bash
 # Build and deploy
-npm run deploy
+pnpm run deploy
 
 # Preview deployment
-npm run preview
+pnpm run preview
 ```
-
-### Production Environment Variables
-
-Set these in your Cloudflare Workers environment:
-- `NEXT_PUBLIC_SITE_URL`: `https://your-domain.com`
-- `NEXT_PUBLIC_GA_ID`: Your Google Analytics ID
 
 ## Project Structure
 
 ```
 ├── src/
-│   ├── app/           # Next.js App Router pages
-│   ├── components/    # React components
-│   └── lib/          # Utility functions
+│   ├── pages/         # Astro pages (file-based routing)
+│   ├── layouts/       # Astro layouts
+│   ├── components/    # UI components
+│   └── lib/           # Utility functions
 ├── posts/            # Blog articles (Markdown)
 ├── docs/             # Documentation and work logs
 ├── todo.md           # Task management
@@ -114,11 +106,10 @@ Set these in your Cloudflare Workers environment:
 
 ## Scripts
 
-- `npm run dev` - Start development server
-- `npm run build` - Build for production
-- `npm run start` - Start production server
-- `npm run deploy` - Deploy to Cloudflare Workers
-- `npm run preview` - Preview Cloudflare deployment locally
+- `pnpm dev` - Start development server
+- `pnpm build` - Build for production
+- `pnpm run deploy` - Build and deploy to Cloudflare Workers
+- `pnpm preview` - Preview the built site locally
 
 ### Favicon Generation
 
@@ -144,10 +135,10 @@ This script generates:
 
 ## Tech Stack
 
-- **Framework**: Next.js 15 with App Router
+- **Framework**: Astro (static output)
 - **Styling**: Tailwind CSS 4
 - **Syntax Highlighting**: Shiki
-- **Deployment**: Cloudflare Workers via OpenNext
+- **Deployment**: Cloudflare Workers (static assets)
 - **Analytics**: Google Analytics 4
 - **Content**: Markdown with gray-matter
 

--- a/docs/adrs/005-static-build-public-env-vars.md
+++ b/docs/adrs/005-static-build-public-env-vars.md
@@ -1,0 +1,121 @@
+# ADR 005: 静的ビルドにおける公開設定値の扱い
+
+## ステータス
+
+承認済み・実装完了（2026-07-15）
+
+## コンテキスト
+
+Astro移行（ADR 003、コミット `a35a303`）後、本番サイトでGoogle Analyticsのデータが取得できなくなっていることが判明した。`wrangler.jsonc` の `vars.PUBLIC_GA_ID` は正しく設定されており、`src/layouts/BaseLayout.astro` も `import.meta.env.PUBLIC_GA_ID` を正しく参照していたが、実際にビルドされた `dist/index.html` にはGAスクリプトが一切出力されていなかった。
+
+### 現状の課題
+
+- Next.js時代（`@next/third-parties`、OpenNext + Cloudflare Workers）では、`process.env.NEXT_PUBLIC_GA_ID` はNext.js Server Componentの**リクエスト時**に評価され、OpenNextのCloudflareアダプターが `wrangler.jsonc` の `vars` を `process.env` に注入していた。そのため `wrangler.jsonc` に値を置くだけで動作した（`docs/worklog/2026-03-20-google-analytics.md` 参照）。
+- Astro移行時（`output: 'static'`、adapterなし）、`wrangler.jsonc` の `vars` の値はそのまま `NEXT_PUBLIC_*` → `PUBLIC_*` にリネームして引き継がれたが、**この値をビルド時に注入する手段が存在しないまま**放置された。
+- 静的Astroサイトの `import.meta.env.PUBLIC_*` はViteによって**ビルド時**に静的置換される。SSRランタイムが存在しない（`wrangler.jsonc` に `main` フィールド＝Workerスクリプトが無く、静的アセット配信のみの構成）ため、`wrangler.jsonc` の `vars` を読む主体はどこにも存在しない。
+- ビルド・デプロイ用のCI/CDワークフローも存在せず、デプロイは手元で `pnpm run deploy`（`astro build && wrangler deploy`）を実行する運用であるため、ビルド時環境変数を注入する自然な導線も無かった。
+- 結果として `wrangler.jsonc` の `vars.PUBLIC_GA_ID` は「設定されているように見えるが実際には何も読まれないデッドコンフィグ」と化し、GAが本番で沈黙していることに長期間気づかれなかった。
+
+## 決定
+
+GA測定IDのような**非機密の公開設定値**は、環境変数ではなく `src/lib/site-config.ts` の `SITE_CONFIG` に定数として直接持たせる。
+
+```ts
+export const SITE_CONFIG = {
+  // ...
+  analytics: {
+    gaId: 'G-WTRHNJ8JBX',
+  },
+};
+```
+
+開発中（`pnpm dev` / `astro preview`）にGAが発火して本番プロパティに開発トラフィックが混入するのを防ぐため、`import.meta.env.PROD` を用いて本番ビルド時のみ有効化する。
+
+```ts
+// src/layouts/BaseLayout.astro
+const GA_ID = import.meta.env.PROD && SITE_CONFIG.analytics.gaId;
+```
+
+`wrangler.jsonc` の `vars` ブロック（`PUBLIC_SITE_URL` / `PUBLIC_GA_ID`）は削除する。静的アセット配信のみの構成ではこの値を読む主体が存在せず、残しておくと「ここで設定すれば効く」という誤解を再生産するため。
+
+### 決定理由
+
+- GA測定IDはビルド後のHTMLに平文で出力される非機密情報であり、ソースコードに直書きしても機密性上の問題はない。
+- 環境変数による上書き機構を持たせると「ビルド時に注入されているはず」という暗黙の前提が生まれ、今回と同種の見えないバグを再発させるリスクがある。定数化すればビルド環境に依存せず常に同じ値がビルド出力に含まれることが保証される。
+- 既存の `PUBLIC_SITE_URL` は `getBaseUrl()`（`src/lib/site-config.ts`）で `import.meta.env.PUBLIC_SITE_URL || SITE_CONFIG.url.base` というフォールバックを持っており、たまたま実害が出なかっただけで、根本的な設計上のリスクは同じだった。今回のGAの一件はこのリスクが顕在化した実例である。
+
+## 検討した選択肢
+
+### 1. `site-config.ts` にフォールバック値を追加（`import.meta.env.PUBLIC_GA_ID || 定数`）
+
+#### 概要
+
+既存の `getBaseUrl()` と同じパターンで、環境変数を優先しつつ定数をフォールバックとして持つ。
+
+#### ✅ 長所
+
+- 既存コードとパターンが統一される
+- ローカルで別のGAプロパティ（検証用）に差し替える手段を残せる
+
+#### ❌ 短所
+
+- ローカル検証用GAプロパティの上書き需要は実際には無かった
+- 環境変数の存在を前提とする設計自体が、今回のバグの温床になった構造を温存する
+
+#### 評価
+
+⭐⭐（検証用の上書き需要が無いため見送り）
+
+---
+
+### 2. 静的アセット配信ではなくAstroの `@astrojs/cloudflare` adapterを導入し、SSR経由でランタイム変数を読む
+
+#### 概要
+
+`wrangler.jsonc` の `vars` を活かすため、Astroをサーバーサイドレンダリング構成に変更し、Cloudflare Workersのランタイム環境変数を読めるようにする。
+
+#### ✅ 長所
+
+- `wrangler.jsonc` の `vars` という既存の仕組みをそのまま活かせる
+
+#### ❌ 短所
+
+- ADR 003で意図的に静的サイト化した経緯（ホスティング制約の回避、シンプルさ）に逆行する
+- GA測定IDのような非機密な公開定数のためだけにSSR化するのは過剰
+
+#### 評価
+
+⭐（スコープに対して過剰な変更）
+
+---
+
+### 3. `site-config.ts` に定数として直接持たせる（採用）
+
+#### 概要
+
+環境変数を介さず、非機密の公開設定値はソースコードの定数として管理する。
+
+#### ✅ 長所
+
+- ビルド環境に依存せず常に正しい値がビルド出力に含まれることが保証される
+- 環境変数の設定漏れという、今回発生したクラスの不具合が構造的に起こり得なくなる
+- 実装がシンプル
+
+#### ❌ 短所
+
+- 値を変更する際にコード変更・デプロイが必要（Cloudinaryの認証情報のような真の機密情報とは異なり、GA IDの変更頻度は低いため許容）
+
+#### 評価
+
+⭐⭐⭐⭐⭐
+
+## 影響
+
+### ポジティブな影響
+
+- GAが本番ビルドで確実に有効化される
+- 今後 `PUBLIC_*` 環境変数を追加する際、「ビルド時に注入されるか」を都度検証する必要性が減り、非機密な公開値は `site-config.ts` に定数化するという判断基準が明確になった
+
+### ネガティブな影響
+
+- GA測定IDを変更する際は環境変数の書き換えではなくコード変更・再デプロイが必要になる（現状の運用頻度を踏まえると許容範囲）

--- a/docs/google-analytics-setup.md
+++ b/docs/google-analytics-setup.md
@@ -2,61 +2,39 @@
 
 ## Prerequisites
 
-This project includes Google Analytics 4 integration using Next.js third-party components.
+This project includes Google Analytics 4 integration implemented directly in `src/layouts/BaseLayout.astro`, using the standard `gtag.js` snippet (no third-party framework package required).
 
-## Setup Steps
+## How it works
 
-### 1. Create Google Analytics 4 Property
+This is a fully static Astro site (`output: 'static'` in `astro.config.ts`, no server adapter). `astro build` runs entirely at build time — there is no server-side runtime that could read environment variables per request. Because of this:
 
-1. Go to [Google Analytics](https://analytics.google.com/)
-2. Create a new account or use an existing one
-3. Create a new GA4 property for your website
-4. Get your Measurement ID (format: `G-XXXXXXXXXX`)
+- The GA4 Measurement ID is defined as a **build-time constant**: `SITE_CONFIG.analytics.gaId` in [`src/lib/site-config.ts`](../src/lib/site-config.ts).
+- `src/layouts/BaseLayout.astro` only enables it when `import.meta.env.PROD` is `true`:
+  ```ts
+  const GA_ID = import.meta.env.PROD && SITE_CONFIG.analytics.gaId;
+  ```
+  This means `pnpm dev` and `astro preview` never load the GA script, so local/dev traffic is never sent to the production GA property.
+- The value in `wrangler.jsonc`'s `vars` field is **not** used — Cloudflare Workers `vars` are runtime bindings for a server-side Worker script, and this project deploys pure static assets (no `main` field / Worker script in `wrangler.jsonc`). Setting a value there has no effect on the built HTML.
 
-### 2. Configure Environment Variables
+## Changing the Measurement ID
 
-1. Copy `.env.local.example` to `.env.local`:
-   ```bash
-   cp .env.local.example .env.local
-   ```
-
-2. Add your Google Analytics Measurement ID:
-   ```
-   NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
-   ```
-   Replace `G-XXXXXXXXXX` with your actual Measurement ID.
-
-### 3. Deploy Configuration
-
-For production deployment, make sure to set the environment variable in your hosting platform:
-
-- **Cloudflare Pages**: Add `NEXT_PUBLIC_GA_ID` in the environment variables section
-- **Vercel**: Add `NEXT_PUBLIC_GA_ID` in project settings
-- **Netlify**: Add `NEXT_PUBLIC_GA_ID` in site settings
+Edit `SITE_CONFIG.analytics.gaId` in `src/lib/site-config.ts` directly, then rebuild and redeploy (`pnpm run deploy`). Since a GA4 Measurement ID is not sensitive (it is already visible in the shipped HTML of any page that loads it), there is no need to keep it out of source control.
 
 ## Verification
 
-1. Start the development server:
+1. Build for production:
    ```bash
-   npm run dev
+   pnpm build
    ```
+2. Check that the GA snippet was inlined:
+   ```bash
+   grep -c "googletagmanager.com/gtag/js" dist/index.html
+   ```
+   Should return a count greater than `0`.
+3. After deploying, open the site in a browser, open DevTools → Network tab, and look for requests to `googletagmanager.com` / `google-analytics.com`.
 
-2. Open your browser's developer tools (F12)
-3. Go to the Network tab
-4. Visit your site and navigate between pages
-5. Look for requests to `google-analytics.com` or `googletagmanager.com`
+## Background: why this isn't an environment variable
 
-## Features Included
+Earlier (Next.js era, before the Astro migration), this project used `NEXT_PUBLIC_GA_ID` read via `process.env` inside a Next.js Server Component, deployed on Cloudflare Workers via OpenNext. In that setup, `process.env` was evaluated **at request time**, and OpenNext's Cloudflare adapter shimmed the Workers runtime's `vars` (from `wrangler.jsonc`) into `process.env` on every request — so setting the value in `wrangler.jsonc` was sufficient.
 
-- ✅ Automatic page view tracking
-- ✅ Client-side navigation tracking (SPA behavior)
-- ✅ Production-only loading (no tracking in development without explicit setup)
-- ✅ Privacy-friendly implementation using Next.js third-parties
-
-## Privacy Considerations
-
-The Google Analytics integration:
-- Only loads when `NEXT_PUBLIC_GA_ID` is set
-- Uses Next.js third-parties for optimized loading
-- Respects user privacy settings when possible
-- Does not track in development environment by default
+After migrating to Astro static output, that runtime shim no longer exists. `import.meta.env.PUBLIC_*` variables in Astro/Vite are resolved once, at build time, from the environment the build process runs in (shell env vars or `.env` files) — never from `wrangler.jsonc`. This mismatch was the root cause of GA silently not firing in production after the migration. See `docs/adrs/005-static-build-public-env-vars.md` for the full decision record.

--- a/docs/plans/2026-07_public-ga-id-google-analytics-id-analyti-sleepy-dragon.md
+++ b/docs/plans/2026-07_public-ga-id-google-analytics-id-analyti-sleepy-dragon.md
@@ -1,0 +1,58 @@
+# PUBLIC_GA_ID が本番ビルドに注入されない問題の修正
+
+## Context
+
+本番サイト（https://blog.zaki-yama.dev/）で Google Analytics のデータが取得できていない。`wrangler.jsonc` には `PUBLIC_GA_ID` が定義されており、`src/layouts/BaseLayout.astro` も `import.meta.env.PUBLIC_GA_ID` を正しく参照しているにもかかわらず、実際にビルドされた `dist/index.html` には `gtag` / `googletagmanager` のスクリプトが一切含まれていないことを確認済み（`grep` で 0 件）。
+
+原因は Next.js → Astro への移行（コミット `a35a303`、2026-03-31）に伴う環境変数の評価タイミングの変化。
+
+- **Next.js 時代**（`@next/third-parties`、`process.env.NEXT_PUBLIC_GA_ID` を Server Component で参照）: OpenNext の Cloudflare アダプター経由で、Cloudflare Workers の `wrangler.jsonc` の `vars` が**リクエスト時（ランタイム）**に `process.env` へ注入されていた。そのため `wrangler.jsonc` に値を置くだけで動作していた（`docs/worklog/2026-03-20-google-analytics.md` に当時の調査記録あり）。
+- **Astro 移行後**（`output: 'static'`、adapter なし）: `import.meta.env.PUBLIC_GA_ID` は Vite によって**ビルド時**に静的置換される。SSR ランタイムが存在しないため、`wrangler.jsonc` の `vars` を読む主体がそもそも存在しない。`wrangler.jsonc` に `main`（Worker スクリプト）フィールドが無いことからも、現状は純粋な静的アセット配信であることが確認できる。
+
+つまり `wrangler.jsonc` の `vars.PUBLIC_GA_ID` は**完全なデッドコンフィグ**であり、ビルド時に値を注入する仕組みがどこにも存在しない。ローカルの `.env.local` にも `PUBLIC_GA_ID` は存在せず（コメントアウトされた旧名 `NEXT_PUBLIC_GA_ID` のみ）、GitHub Actions にもビルド・デプロイ用ワークフローが無い（デプロイは手元で `pnpm run deploy`＝`astro build && wrangler deploy` を実行する運用）。
+
+なお、同じ静的ビルド時評価の問題を抱える `PUBLIC_SITE_URL` は `getBaseUrl()`（`src/lib/site-config.ts:33-35`）で `import.meta.env.PUBLIC_SITE_URL || SITE_CONFIG.url.base` というフォールバックを持っているため、実害なく動いていた。GA_ID にはこのフォールバックが無かったため、`GA_ID` が `undefined` になり `{GA_ID && (...)}` の条件分岐でスクリプト自体が出力されなかった。
+
+対応方針はユーザーと相談の上、環境変数による上書き機構（`PUBLIC_GA_ID`）自体を廃止し、**`SITE_CONFIG` に GA 測定 ID を定数として持たせる**方式を採用する（GA 測定 ID はビルド後の HTML に平文で出力される非機密情報であり、`wrangler.jsonc` にも既に平文で存在しているため、ソースにハードコードしても機密性上の問題はない）。ただし、現状は開発時（`pnpm dev` / `astro preview`）には GA スクリプトが出力されない（＝開発中のアクセスが本番 Analytics に混入しない）という挙動になっているため、これを維持する。Astro/Vite のビルドモード判定 `import.meta.env.PROD` を使い、本番ビルド時のみ GA_ID を有効にする。
+
+## 対応内容
+
+### 1. コード修正
+
+**`src/lib/site-config.ts`**
+- `SITE_CONFIG` に `analytics: { gaId: 'G-WTRHNJ8JBX' }` を追加
+
+**`src/layouts/BaseLayout.astro`**
+- `const GA_ID = import.meta.env.PUBLIC_GA_ID;` を以下に置き換え:
+  ```ts
+  const GA_ID = import.meta.env.PROD ? SITE_CONFIG.analytics.gaId : undefined;
+  ```
+
+### 2. `wrangler.jsonc` のクリーンアップ
+- `vars` ブロック（`PUBLIC_SITE_URL` / `PUBLIC_GA_ID`）を削除する。静的アセット配信のみの構成（`main` フィールドなし）ではこの `vars` を読むランタイムが存在せず、残しておくと「ここで設定すれば効く」という誤解を再生産するため。
+- なお `PUBLIC_SITE_URL` 側（`getBaseUrl()`）は今回スコープ外とし、既存のフォールバック実装のまま変更しない。
+
+### 3. `.env.local.example` の更新
+- `NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX` の行を削除する（環境変数による上書きを廃止するため、GA 関連の設定項目自体が不要になる）
+
+### 4. ドキュメント更新
+
+**`README.md`**
+- 「Next.js 15」等の技術スタック記述を Astro ベースに更新
+- `npm run dev` 等のコマンドを `pnpm dev` に統一（CLAUDE.md の pnpm 方針に合わせる）
+- GA 設定に関する記述を、実際の仕組み（`SITE_CONFIG.analytics.gaId` に直接定義、環境変数は使わない、本番ビルド時のみ有効）に修正
+
+**`docs/google-analytics-setup.md`**
+- Next.js 前提（`@next/third-parties`、Server/Client Component の話、`NEXT_PUBLIC_GA_ID` の設定手順）の内容を Astro 前提に書き直し
+- GA ID は `src/lib/site-config.ts` の定数として管理すること、`import.meta.env.PROD` により本番ビルド時のみ有効になることを明記
+- `wrangler.jsonc` の `vars` では効かないこと（static assets 配信ではランタイムが存在しないため）を明記
+
+**新規 ADR: `docs/adrs/005-static-build-public-env-vars.md`**
+- `docs/adrs/000-template.md` のフォーマットに従う
+- 今回の根本原因（SSR ランタイム評価 vs. static ビルド時評価の違い、`wrangler.jsonc` の `vars` が static assets 構成では無効であること）と、非機密な公開設定値は `site-config.ts` に定数として持たせる、という決定を記録する。将来同じ問題を繰り返さないための記録として残す。
+
+## 検証方法
+
+1. `pnpm build` を実行し、`grep -c "gtag\|G-WTRHNJ8JBX" dist/index.html` が 0 より大きいことを確認する（現状は 0 件であることを確認済み）。
+2. `pnpm dev` （または `astro build --mode development`）で `GA_ID` が `undefined` になり GA スクリプトが出力されないこと（開発時は計測されない挙動が維持されていること）を確認する。
+3. 本番反映は `pnpm run deploy` の実行が必要（別途ユーザーの許可を得てから実施）。

--- a/docs/worklog/2026-07-15-google-analytics-not-tracked-fix.md
+++ b/docs/worklog/2026-07-15-google-analytics-not-tracked-fix.md
@@ -1,0 +1,34 @@
+# 2026-07-15 作業ログ
+
+## 今日やったこと
+
+- 本番サイトでGoogle Analyticsが計測できていない問題を調査し、原因と対応方針を確定
+- Explore agentと自分の調査を並行させ、`wrangler.jsonc` の `vars.PUBLIC_GA_ID` がAstro静的ビルドでは完全に無効なデッドコンフィグになっていることを特定
+- ユーザーと相談し、環境変数による上書き機構自体を廃止して `site-config.ts` に定数化する方針に決定
+- `src/lib/site-config.ts` に `SITE_CONFIG.analytics.gaId` を追加、`BaseLayout.astro` を `import.meta.env.PROD && SITE_CONFIG.analytics.gaId` に変更
+- `wrangler.jsonc` の `vars` ブロックを削除、`.env.local.example` からGA関連行を削除
+- `README.md` と `docs/google-analytics-setup.md` をNext.js前提の記述からAstro前提に書き直し
+- 新規ADR `005-static-build-public-env-vars.md` を作成し、根本原因と決定を記録
+- `pnpm build` で本番ビルドにGAスクリプトが出力されること、`astro dev` では出力されないこと（開発トラフィックが混入しない）を実機確認
+
+## 直面した課題
+
+- ユーザーが「Nestから移行した」と言っていたが、実際には NestJS ではなく Next.js からの移行だった。`git log` で確認して訂正。ユーザー自身の記憶違い・言い間違いだった可能性が高い。
+- 当初、既存の `getBaseUrl()` パターン（`import.meta.env.PUBLIC_GA_ID || 定数`）を踏襲する案で計画したが、ユーザーから「ローカル上書きが不要なら定数だけにできないか」と指摘され、よりシンプルな設計に倒した。ただしその際、開発時にGAが発火してしまう副作用に気づき、`import.meta.env.PROD` によるガードを追加する必要があった。
+- `astro build --mode development` では `import.meta.env.PROD` が変化しないことに気づかず、最初の検証方法が誤っていた。`PROD`/`DEV` はVite的には「ビルドかdevサーバーか」で決まり、`--mode` フラグとは独立していることを実際に `astro dev` を起動して確認して理解した。
+
+## 感情的な変化
+
+- `docs/worklog/2026-03-20-google-analytics.md` という過去の作業ログが、まさに「Next.js Server Componentのランタイム評価だからwrangler.jsoncのvarsで動く」という結論を出していたのを見つけたとき、移行時にこの前提が引き継がれずに壊れた瞬間が特定できて腑に落ちた。過去の自分（Claude）の調査ログが今回の調査の決定的な証拠になったのは面白かった。
+- 実際に `dist/index.html` をgrepしてGAスクリプトが0件であることを最初に確認できたのが大きく、仮説ベースではなく実証ベースで原因を詰められた。
+
+## 技術的な学び
+
+- OpenNext + Cloudflare WorkersでのNext.js Server Componentは、`process.env` をリクエスト時に評価し、Workersの`vars`をランタイムで注入できる。一方、Astroの静的ビルド（`output: 'static'`、adapterなし）は `import.meta.env.PUBLIC_*` をビルド時にVarsで静的置換するため、両者は全く異なる評価タイミングを持つ。同じ「環境変数っぽい書き方」でもフレームワーク移行で意味が変わる典型例だった。
+- `wrangler.jsonc` の `vars` は、Workerスクリプト（`main`フィールド）が存在する場合にのみ意味を持つランタイムバインディングであり、静的アセットのみの配信構成では完全に無視される。
+- Viteの `import.meta.env.PROD` / `DEV` は `--mode` フラグとは独立していて、`vite build` / `astro build` は常に `PROD: true`、`vite dev` / `astro dev` のみ `DEV: true` になる。
+
+## 次回への引き継ぎ
+
+- `pnpm run deploy` の実行によるデプロイ自体はユーザーの承認前提でまだ実施していない。次回セッション、もしくはこのセッションの続きでユーザーに確認の上、本番反映する。
+- README.mdのFavicon生成セクション（`scripts/generate-favicon.sh`）が実際には存在しないスクリプトを参照している、Cloudinary関連の環境変数（`NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME`等）もコード内に実際の参照箇所が見当たらず未使用の可能性がある、という2点はスコープ外として今回は触れなかった。別issueとして対応を検討してもよい。

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,7 +15,7 @@ const {
   ogImageUrl,
 } = Astro.props;
 
-const GA_ID = import.meta.env.PUBLIC_GA_ID;
+const GA_ID = import.meta.env.PROD && SITE_CONFIG.analytics.gaId;
 const siteUrl = import.meta.env.PUBLIC_SITE_URL || SITE_CONFIG.url.base;
 const canonicalUrl = new URL(Astro.url.pathname, siteUrl).toString();
 ---

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -25,6 +25,11 @@ export const SITE_CONFIG = {
 
   // SEO
   keywords: ['プログラミング', '技術ブログ', 'エンジニア', 'Web開発'] as string[],
+
+  // Analytics
+  analytics: {
+    gaId: 'G-WTRHNJ8JBX',
+  },
 };
 
 /**

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,9 +13,5 @@
 			"pattern": "blog.zaki-yama.dev",
 			"custom_domain": true
 		}
-	],
-	"vars": {
-		"PUBLIC_SITE_URL": "https://blog.zaki-yama.dev",
-		"PUBLIC_GA_ID": "G-WTRHNJ8JBX"
-	}
+	]
 }


### PR DESCRIPTION
## Summary
- Astro移行後、`wrangler.jsonc` の `vars.PUBLIC_GA_ID` が静的ビルドでは一切参照されず（Workerランタイムを持たない静的アセット配信構成のため）、本番でGAスクリプトが出力されていなかった問題を修正
- GA測定IDを `SITE_CONFIG.analytics.gaId`（`src/lib/site-config.ts`）にビルド時定数として持たせ、`import.meta.env.PROD` で本番ビルド時のみ有効化するよう変更
- Next.js時代のまま更新されていなかった `README.md` / `docs/google-analytics-setup.md` をAstro実態に合わせて更新
- 根本原因と決定事項を `docs/adrs/005-static-build-public-env-vars.md` に記録

## Test plan
- [x] `pnpm build` で `dist/index.html` にGAスクリプト(`googletagmanager.com/gtag/js`)が出力されることを確認
- [x] `astro dev` ではGAスクリプトが出力されない(開発トラフィックが本番GAプロパティに混入しない)ことを確認
- [x] `pnpm lint` で今回の変更起因のエラー・警告がないことを確認
- [ ] マージ後、`pnpm run deploy` で本番反映し、本番サイトのHTMLに実際にGAスクリプトが含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)