### PR TITLE
Disable Shiki line wrap so code blocks scroll horizontally

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -100,7 +100,7 @@ export default defineConfig({
   markdown: {
     shikiConfig: {
       theme: 'dark-plus',
-      wrap: true,
+      wrap: false,
       transformers: [transformerFilename()],
     },
     syntaxHighlight: {


### PR DESCRIPTION
overflow-x: auto was already set on .prose pre.astro-code in global.css,
but shikiConfig.wrap: true made Shiki emit pre-wrap styling, causing
long lines to wrap instead of scroll.