### PR TITLE
feat: add copy button to code blocks

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -11,6 +11,7 @@ import { rehypeTwitterEmbed } from './src/lib/rehype-twitter-embed';
 import { rehypeLinkCard } from './src/lib/rehype-link-card';
 import { rehypeMermaid } from './src/lib/rehype-mermaid';
 import { transformerFilename } from './src/lib/shiki-transformer-filename';
+import { transformerCopyButton } from './src/lib/shiki-transformer-copy-button';
 
 function rehypeHeadingIds() {
   return (tree: any) => {
@@ -101,7 +102,9 @@ export default defineConfig({
     shikiConfig: {
       theme: 'dark-plus',
       wrap: false,
-      transformers: [transformerFilename()],
+      // copy-button must run before filename: filename replaces <pre> with a
+      // wrapping <div>, so the button needs to be appended while it's still <pre>.
+      transformers: [transformerCopyButton(), transformerFilename()],
     },
     syntaxHighlight: {
       type: 'shiki',

--- a/src/lib/copy-code-client.ts
+++ b/src/lib/copy-code-client.ts
@@ -1,0 +1,33 @@
+const COPIED_LABEL = 'コピーしました';
+const DEFAULT_LABEL = 'コードをコピー';
+const COPIED_DURATION_MS = 2000;
+
+async function copyCode(button: HTMLButtonElement) {
+  const code = button.dataset.code ?? '';
+
+  try {
+    await navigator.clipboard.writeText(code);
+  } catch {
+    return;
+  }
+
+  window.clearTimeout(Number(button.dataset.resetTimeoutId));
+
+  button.classList.add('copied');
+  button.setAttribute('aria-label', COPIED_LABEL);
+
+  const timeoutId = window.setTimeout(() => {
+    button.classList.remove('copied');
+    button.setAttribute('aria-label', DEFAULT_LABEL);
+  }, COPIED_DURATION_MS);
+  button.dataset.resetTimeoutId = String(timeoutId);
+}
+
+export function initCopyCodeButtons() {
+  document.addEventListener('click', (event) => {
+    const button = (event.target as HTMLElement).closest<HTMLButtonElement>('.copy-code-button');
+    if (!button) return;
+
+    copyCode(button);
+  });
+}

--- a/src/lib/shiki-transformer-copy-button.ts
+++ b/src/lib/shiki-transformer-copy-button.ts
@@ -1,0 +1,82 @@
+import type { Element } from 'hast';
+import type { ShikiTransformer } from 'shiki';
+
+// Adds a "copy code" button as a child of the generated <pre>, positioned via
+// CSS. Must run before transformerFilename() in the transformers list: that
+// transformer replaces the <pre> node with a wrapping <div>, so this hook
+// needs to append the button while `node` is still the real <pre> element.
+export function transformerCopyButton(): ShikiTransformer {
+  return {
+    name: 'copy-button',
+    pre(node): void {
+      node.children.push(createCopyButton(this.source));
+    },
+  };
+}
+
+function createCopyButton(code: string): Element {
+  return {
+    type: 'element',
+    tagName: 'button',
+    properties: {
+      type: 'button',
+      className: ['copy-code-button'],
+      ariaLabel: 'コードをコピー',
+      'data-code': code,
+    },
+    children: [
+      {
+        type: 'element',
+        tagName: 'svg',
+        properties: {
+          className: ['icon-copy'],
+          xmlns: 'http://www.w3.org/2000/svg',
+          viewBox: '0 0 24 24',
+          fill: 'none',
+          stroke: 'currentColor',
+          strokeWidth: '2',
+          strokeLinecap: 'round',
+          strokeLinejoin: 'round',
+          ariaHidden: 'true',
+        },
+        children: [
+          {
+            type: 'element',
+            tagName: 'rect',
+            properties: { x: '9', y: '9', width: '13', height: '13', rx: '2', ry: '2' },
+            children: [],
+          },
+          {
+            type: 'element',
+            tagName: 'path',
+            properties: { d: 'M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1' },
+            children: [],
+          },
+        ],
+      },
+      {
+        type: 'element',
+        tagName: 'svg',
+        properties: {
+          className: ['icon-check'],
+          xmlns: 'http://www.w3.org/2000/svg',
+          viewBox: '0 0 24 24',
+          fill: 'none',
+          stroke: 'currentColor',
+          strokeWidth: '2',
+          strokeLinecap: 'round',
+          strokeLinejoin: 'round',
+          ariaHidden: 'true',
+        },
+        children: [
+          {
+            type: 'element',
+            tagName: 'polyline',
+            properties: { points: '20 6 9 17 4 12' },
+            children: [],
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -86,6 +86,10 @@ const hasMermaid = containsMermaidBlock(post.body ?? '');
         <div class="prose prose-lg max-w-none">
           <Content />
         </div>
+        <script>
+          import { initCopyCodeButtons } from '../../lib/copy-code-client';
+          initCopyCodeButtons();
+        </script>
         {hasMermaid && <script>import { initMermaid } from '../../lib/mermaid-client'; initMermaid();</script>}
         {hasTwitterEmbed && <script async src="https://platform.twitter.com/widgets.js" charset="utf-8" />}
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -158,10 +158,60 @@ body {
 
 /* Shiki code block styling */
 .prose pre.astro-code {
+  position: relative;
   border-radius: 0.5rem;
   margin: 1.5rem 0;
   padding: 1.25rem;
   overflow-x: auto;
+}
+
+/* Copy-to-clipboard button, injected into every code block by
+   shiki-transformer-copy-button.ts. Colors are fixed (not theme-dependent)
+   like .code-filename below, since the code block itself is always dark. */
+.prose .copy-code-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border-radius: 0.375rem;
+  border: 1px solid transparent;
+  background-color: rgb(255 255 255 / 0.08);
+  color: #9ca3af;
+  cursor: pointer;
+  transition:
+    background-color 0.15s,
+    color 0.15s;
+}
+
+.prose .copy-code-button:hover {
+  background-color: rgb(255 255 255 / 0.16);
+  color: #f9fafb;
+}
+
+.prose .copy-code-button svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.prose .copy-code-button .icon-check {
+  display: none;
+}
+
+.prose .copy-code-button.copied {
+  color: #4ade80;
+}
+
+.prose .copy-code-button.copied .icon-copy {
+  display: none;
+}
+
+.prose .copy-code-button.copied .icon-check {
+  display: block;
 }
 
 /* Filename title bar for ```lang:filename``` code blocks */


### PR DESCRIPTION
Adds a copy-to-clipboard button to the top-right corner of every code
block, via a Shiki transformer that injects the button into the
generated <pre>. Clicking it copies the code and briefly swaps the
icon to a checkmark as feedback.

Closes #34

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LtMDcHpyyvNVZGLYNZndXf